### PR TITLE
Defer Jackson parsing to the main thread to prevent java.net.http executor starvation

### DIFF
--- a/src/main/java/com/cosium/matrix_communication_client/MatrixApi.java
+++ b/src/main/java/com/cosium/matrix_communication_client/MatrixApi.java
@@ -54,7 +54,11 @@ class MatrixApi {
             .build();
 
     try {
-      return httpClient.send(request, jsonHandlers.handler(CreatedEvent.class)).body().parse();
+      return httpClient
+          .send(request, jsonHandlers.handler(CreatedEvent.class))
+          .body()
+          .get()
+          .parse();
     } catch (IOException e) {
       throw new RuntimeException(e);
     } catch (InterruptedException e) {
@@ -74,7 +78,11 @@ class MatrixApi {
             .build();
 
     try {
-      return httpClient.send(request, jsonHandlers.handler(CreateRoomOutput.class)).body().parse();
+      return httpClient
+          .send(request, jsonHandlers.handler(CreateRoomOutput.class))
+          .body()
+          .get()
+          .parse();
     } catch (IOException e) {
       throw new RuntimeException(e);
     } catch (InterruptedException e) {
@@ -93,7 +101,11 @@ class MatrixApi {
             .build();
 
     try {
-      return httpClient.send(request, jsonHandlers.handler(RawClientEvent.class)).body().parse();
+      return httpClient
+          .send(request, jsonHandlers.handler(RawClientEvent.class))
+          .body()
+          .get()
+          .parse();
     } catch (IOException e) {
       throw new RuntimeException(e);
     } catch (InterruptedException e) {
@@ -124,6 +136,7 @@ class MatrixApi {
       return httpClient
           .send(request, jsonHandlers.handler(RawClientEventPage.class))
           .body()
+          .get()
           .parse();
     } catch (IOException e) {
       throw new RuntimeException(e);

--- a/src/main/java/com/cosium/matrix_communication_client/MatrixUnprotectedApi.java
+++ b/src/main/java/com/cosium/matrix_communication_client/MatrixUnprotectedApi.java
@@ -36,7 +36,11 @@ class MatrixUnprotectedApi {
             .build();
 
     try {
-      return httpClient.send(loginRequest, jsonHandlers.handler(LoginOutput.class)).body().parse();
+      return httpClient
+          .send(loginRequest, jsonHandlers.handler(LoginOutput.class))
+          .body()
+          .get()
+          .parse();
     } catch (IOException e) {
       throw new RuntimeException(e);
     } catch (InterruptedException e) {

--- a/src/main/java/com/cosium/matrix_communication_client/WellKnownMatrixClient.java
+++ b/src/main/java/com/cosium/matrix_communication_client/WellKnownMatrixClient.java
@@ -34,7 +34,8 @@ class WellKnownMatrixClient {
                       .GET()
                       .build(),
                   jsonHandlers.handler(WellKnownMatrixClient.class))
-              .body();
+              .body()
+              .get();
       if (response.isNotFound()) {
         return Optional.empty();
       }


### PR DESCRIPTION
This is recommended by `HttpResponse.BodySubscribers#mapping` javadoc.